### PR TITLE
bare Ui for selector

### DIFF
--- a/src/startup/selector.py
+++ b/src/startup/selector.py
@@ -1,0 +1,73 @@
+"""
+selector.py
+-----------
+Popup selector window for choosing the UI mode.
+
+This module must remain lightweight and must not import or initialize
+the full Tkinter or PyQt UI systems. It only provides a small modal
+window that returns a StartupMode value.
+"""
+
+from .modes import StartupMode
+
+try:
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:
+    tk = None
+    ttk = None
+
+
+class StartupSelector:
+    """
+    A minimal Tkinter-based popup selector window.
+    Returns a StartupMode based on user selection.
+    """
+
+    def __init__(self):
+        if tk is None:
+            raise RuntimeError("Tkinter is not available on this system.")
+
+        self.result = None
+        self.root = tk.Tk()
+        self.root.title("Select Mode")
+        self.root.geometry("300x200")
+        self.root.resizable(False, False)
+
+        # Center window
+        self.root.eval("tk::PlaceWindow . center")
+
+        # ESC closes
+        self.root.bind("<Escape>", lambda e: self._close())
+
+        self._build_ui()
+
+    def _build_ui(self):
+        frame = ttk.Frame(self.root, padding=20)
+        frame.pack(expand=True, fill="both")
+
+        ttk.Label(frame, text="Choose Startup Mode", font=("Segoe UI", 12)).pack(pady=(0, 10))
+
+        ttk.Button(frame, text="Basic | Tkinter",
+                   command=lambda: self._select(StartupMode.TK)).pack(fill="x", pady=4)
+
+        ttk.Button(frame, text="Advanced | PyQt",
+                   command=lambda: self._select(StartupMode.PYQT)).pack(fill="x", pady=4)
+
+        ttk.Button(frame, text="RAW (coming soon)", state="disabled").pack(fill="x", pady=4)
+
+        ttk.Button(frame, text="Close",
+                   command=self._close).pack(fill="x", pady=(10, 0))
+
+    def _select(self, mode):
+        self.result = mode
+        self.root.destroy()
+
+    def _close(self):
+        self.result = None
+        self.root.destroy()
+
+    def show(self) -> StartupMode | None:
+        """Show the popup and block until closed."""
+        self.root.mainloop()
+        return self.result


### PR DESCRIPTION
# **Pull Request**

Thank you for contributing to SchedPlus!  
Please complete the sections below to help us review your PR.

---

## **Summary**

This PR implements the **popup selector window** used when SchedPlus is launched **without CLI flags**.  
It is part of Issue **#41 — Startup Mode Selector**, specifically sub‑issue **#45**.

The popup provides a simple, lightweight UI for choosing between:

- **Basic | Tkinter**
- **Advanced | PyQt**
- **RAW (disabled)**
- **Close**

This PR introduces a minimal Tkinter‑based modal dialog that returns a `StartupMode` value to the caller.  
No startup orchestration or UI launching is included in this PR.

---

## **Type of Change**

- [x] New feature  
- [x] UI/UX improvement  
- [x] Workflow improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## **Details**

### **What was implemented**
- Added new file: `startup/selector.py`
- Implemented a **lightweight Tkinter popup** that:
  - Centers itself on screen  
  - Blocks until user chooses an option  
  - Provides buttons for TK, PYQT, RAW (disabled), and Close  
  - Supports ESC to close  
  - Returns a `StartupMode` enum value  

### **Design decisions**
- Tkinter was chosen for the popup because:
  - It is available by default on Windows + Linux  
  - It loads instantly  
  - It avoids pulling in heavy PyQt dependencies  
- The popup is intentionally minimal and neutral in appearance  
- No full UI modules (Tkinter UI or PyQt UI) are imported  
- No scheduler, storage, or controller logic is touched  

### **Side effects**
- None  
- Existing startup flow remains unchanged until #46 (Startup Controller)  
- No changes to main.py in this PR  

---

## **Testing**

Manual testing performed:

- [x] Runs successfully  
- [x] Tested on Linux (WSL GUI)  
- [ ] Tested on Windows  
- [x] Popup appears when invoked directly  
- [x] Buttons return correct `StartupMode` values  
- [x] RAW button is disabled  
- [x] ESC closes the popup  
- [x] No regressions found  

---

## **Related Issues**

Fixes **#45**  
Related to **#41 — Startup Mode Selector**  
Prepares for **#46 — Startup Controller**

---

## **Additional Notes (optional)**

This popup will be integrated into the full startup flow in the next PR (#46).  
It is intentionally minimal and will later be replaced or themed once the PyQt redesign (#31) is underway.

---
