### PR TITLE
feat: file resolver

### DIFF
--- a/src/storage/paths.py
+++ b/src/storage/paths.py
@@ -1,0 +1,43 @@
+"""
+paths.py
+--------
+Cross-platform storage path resolver for SchedPlus.
+
+This module defines where persistent data is stored, including:
+- SQLite database file
+- Legacy JSON file (for migration)
+"""
+
+import os
+from appdirs import user_data_dir
+
+
+APP_NAME = "SchedPlus"
+APP_AUTHOR = "ZFordDev"  # optional, used on Windows
+
+
+def resolve_storage_dir() -> str:
+    """
+    Returns the directory where SchedPlus stores all persistent data.
+    Creates the directory if it does not exist.
+    """
+    path = user_data_dir(APP_NAME, APP_AUTHOR)
+
+    if not os.path.exists(path):
+        os.makedirs(path, exist_ok=True)
+
+    return path
+
+
+def get_db_path() -> str:
+    """
+    Returns the full path to the SQLite database file.
+    """
+    return os.path.join(resolve_storage_dir(), "schedplus.db")
+
+
+def get_json_path() -> str:
+    """
+    Returns the full path to the legacy JSON file (for migration).
+    """
+    return os.path.join(resolve_storage_dir(), "tasks.json")


### PR DESCRIPTION
# **Pull Request**

Thank you for contributing to SchedPlus!  
Please complete the sections below to help us review your PR.

---

## **Summary**

This PR implements the **cross‑platform storage path resolver** for the new database‑backed logic layer defined in Issue #42.

It introduces a dedicated `storage/` module and provides a single source of truth for where SchedPlus stores persistent data.  
This is the foundation for upcoming work on the SQLite engine, repository API, and JSON→DB migration.

No database logic is included in this PR.

---

## **Type of Change**

- [x] New feature  
- [x] Workflow improvement  
- [ ] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## **Details**

### **What this PR adds**
- New folder: `storage/`
- New module: `storage/paths.py`
- Functions implemented:
  - **resolve_storage_dir** — returns and creates the app data directory  
  - **get_db_path** — returns the full path to `schedplus.db`  
  - **get_json_path** — returns the full path to the legacy `tasks.json` file  
- Uses `appdirs` to ensure correct OS‑specific paths on Windows + Linux/WSL  
- No DB creation, no JSON reading, and no scheduler integration yet  
- This module is fully UI‑agnostic and contains no UI imports  

### **Design decisions**
- A dedicated `storage/` package is created to house all future DB, repository, and migration logic  
- Path resolution is isolated so the rest of the logic layer remains clean and platform‑independent  
- `get_json_path()` is included even though JSON storage is no longer active, because the migration system (#42D) will require it  

### **Side effects**
- None  
- No changes to existing logic or UI  
- No DB or JSON files are created automatically  

---

## **Testing**

A small, temporary test harness (not included in this PR) was used to validate:

- [x] Runs successfully  
- [x] Tested on Linux (WSL)  
- [ ] Tested on Windows  
- [x] Directory is created if missing  
- [x] DB path resolves correctly  
- [x] JSON path resolves correctly  
- [x] No regressions found  

---

## **Related Issues**

Fixes **#42A**  
Part of **#42 — Logic Layer Overhaul (JSON → SQLite)**  

---

## **Additional Notes (optional)**
